### PR TITLE
Publish 1.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@
 {% set Y = 0 %}
 package:
   name: mpi
-  version: 1.{{ Y }}.1
+  version: 1.{{ Y }}.0
 
 build:
   # We mustn't use the build number in the mpi package - because we are defining the string,


### PR DESCRIPTION
Avoids problem with 1.0 noarch version in conda not handling `x.y` versions in `noarch: generic` packages.

I _believe_ I've confirmed in local testing that this closes #17 by running this build with `1.0`, `1.0.0`, and `1.0.1`. The current pin in openmpi, etc. packages accepts `1.0.0` and the conda bug doesn't surface for subsequent builds, when it does for the `1.0` builds.

